### PR TITLE
Add RET binding to exit text movement menus

### DIFF
--- a/lisp/casual-editkit-utils.el
+++ b/lisp/casual-editkit-utils.el
@@ -351,7 +351,8 @@ Commands pertaining to move word operations can be accessed here."
   ["Move Word"
    :class transient-row
    ("b" "Backward"  casual-editkit-move-word-backward :transient t)
-   ("f" "Forward"  casual-editkit-move-word-forward :transient t)]
+   ("f" "Forward"  casual-editkit-move-word-forward :transient t)
+   ("RET" "Done" transient-quit-all)]
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 
@@ -362,7 +363,8 @@ Commands pertaining to move sentence operations can be accessed here."
   ["Move Sentence"
    :class transient-row
    ("b" "Backward"  casual-editkit-move-sentence-backward :transient t)
-   ("f" "Forward"  casual-editkit-move-sentence-forward :transient t)]
+   ("f" "Forward"  casual-editkit-move-sentence-forward :transient t)
+   ("RET" "Done" transient-quit-all)]
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 
@@ -374,7 +376,8 @@ can be accessed here."
   ["Move Sexp"
    :class transient-row
    ("b" "Backward"  casual-editkit-move-sexp-backward :transient t)
-   ("f" "Forward"  casual-editkit-move-sexp-forward :transient t)]
+   ("f" "Forward"  casual-editkit-move-sexp-forward :transient t)
+   ("RET" "Done" transient-quit-all)]
   casual-editkit-cursor-navigation-group
   casual-editkit-navigation-group)
 

--- a/tests/test-casual-editkit-utils.el
+++ b/tests/test-casual-editkit-utils.el
@@ -328,7 +328,8 @@
 
       (let ((test-vectors
              '((:binding "b" :command casual-editkit-move-word-backward)
-               (:binding "f" :command casual-editkit-move-word-forward))))
+               (:binding "f" :command casual-editkit-move-word-forward)
+               (:binding "RET" :command transient-quit-all))))
 
         (casualt-suffix-testcase-runner test-vectors
                                         #'casual-editkit-move-word-tmenu
@@ -342,7 +343,8 @@
 
       (let ((test-vectors
              '((:binding "b" :command casual-editkit-move-sentence-backward)
-               (:binding "f" :command casual-editkit-move-sentence-forward))))
+               (:binding "f" :command casual-editkit-move-sentence-forward)
+               (:binding "RET" :command transient-quit-all))))
 
         (casualt-suffix-testcase-runner test-vectors
                                         #'casual-editkit-move-sentence-tmenu
@@ -356,7 +358,8 @@
 
       (let ((test-vectors
              '((:binding "b" :command casual-editkit-move-sexp-backward)
-               (:binding "f" :command casual-editkit-move-sexp-forward))))
+               (:binding "f" :command casual-editkit-move-sexp-forward)
+               (:binding "RET" :command transient-quit-all))))
 
         (casualt-suffix-testcase-runner test-vectors
                                         #'casual-editkit-move-sexp-tmenu


### PR DESCRIPTION
- Adds RET binding to exit text movement menus for:
  - word
  - sentence
  - balanced expression (sexp)
