### PR TITLE
Fix byte-compilation ordering issues

### DIFF
--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -27,6 +27,7 @@ endif
 
 PACKAGE_NAME=casual-editkit
 ELISP_INCLUDES=casual-editkit-version.el	\
+casual-editkit-constants.el			\
 casual-editkit-utils.el				\
 casual-editkit-settings.el
 ELISP_PACKAGES=

--- a/lisp/casual-editkit-constants.el
+++ b/lisp/casual-editkit-constants.el
@@ -1,0 +1,77 @@
+;;; casual-editkit-constants.el --- Constants file for Casual EditKit  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024  Charles Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools, wp
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+(require 'simple)
+(require 'casual-lib)
+
+(defconst casual-editkit-unicode-db
+  '((:previous . '("↑" "previous"))
+    (:next . '("↓" "next"))
+    (:point-up . '("↑" "Up"))
+    (:point-down . '("↓" "Down"))
+    (:point-left . '("←" "Left"))
+    (:point-right . '("→" "Right"))
+    (:other-window . '("»" "Other"))
+    (:delete-other-windows . '("❏" "Delete other"))
+    (:split-window-below . '("⇩" "Window below"))
+    (:split-window-horizontally . '("⇨" "Window right"))
+    (:enlarge . '("+" "Enlarge"))
+    (:shrink . '("−" "Shrink"))
+    (:horizontal . '("⦵" "Horizontal"))
+    (:vertical . '("⏀" "Vertical"))
+    (:first . '("⤒" "first"))
+    (:last . '("⤓" "last"))
+    (:swap . '("⇄" "Swap"))
+    (:jump . '("🚀" "Jump")))
+  "Unicode symbol DB to use for Bookmarks Transient menus.")
+
+(defun casual-editkit-unicode-get (key)
+  "Lookup Unicode symbol for KEY in DB.
+
+- KEY symbol used to lookup Unicode symbol in DB.
+
+If the value of customizable variable `casual-lib-use-unicode'
+is non-nil, then the Unicode symbol is returned, otherwise a
+plain ASCII-range string."
+  (casual-lib-unicode-db-get key casual-editkit-unicode-db))
+
+(defconst casual-editkit-navigation-group
+  [:class transient-row
+   (casual-lib-quit-one)
+   ("U" "Undo" undo :transient t)
+   (casual-lib-quit-all)]
+  "Transient navigation group for Casual EditKit menus.")
+
+(defconst casual-editkit-cursor-navigation-group
+  ["Cursor"
+   :class transient-row
+   ("<left>" "←" backward-char :transient t)
+   ("<right>" "→" forward-char :transient t)
+   ("<up>" "↑" previous-line :transient t)
+   ("<down>" "↓" next-line :transient t)]
+  "Transient cursor navigation group for Casual EditKit menus.")
+
+(provide 'casual-editkit-constants)
+;;; casual-editkit-constants.el ends here

--- a/lisp/casual-editkit-settings.el
+++ b/lisp/casual-editkit-settings.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2024 Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
-;; Keywords: tools
+;; Keywords: tools, wp
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/lisp/casual-editkit-utils.el
+++ b/lisp/casual-editkit-utils.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2024 Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
-;; Keywords: tools
+;; Keywords: tools, wp
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -31,53 +31,7 @@
 (require 'magit-files)
 (require 'symbol-overlay)
 (require 'casual-lib)
-
-(defconst casual-editkit-unicode-db
-  '((:previous . '("↑" "previous"))
-    (:next . '("↓" "next"))
-    (:point-up . '("↑" "Up"))
-    (:point-down . '("↓" "Down"))
-    (:point-left . '("←" "Left"))
-    (:point-right . '("→" "Right"))
-    (:other-window . '("»" "Other"))
-    (:delete-other-windows . '("❏" "Delete other"))
-    (:split-window-below . '("⇩" "Window below"))
-    (:split-window-horizontally . '("⇨" "Window right"))
-    (:enlarge . '("+" "Enlarge"))
-    (:shrink . '("−" "Shrink"))
-    (:horizontal . '("⦵" "Horizontal"))
-    (:vertical . '("⏀" "Vertical"))
-    (:first . '("⤒" "first"))
-    (:last . '("⤓" "last"))
-    (:swap . '("⇄" "Swap"))
-    (:jump . '("🚀" "Jump")))
-  "Unicode symbol DB to use for Bookmarks Transient menus.")
-
-(defun casual-editkit-unicode-get (key)
-  "Lookup Unicode symbol for KEY in DB.
-
-- KEY symbol used to lookup Unicode symbol in DB.
-
-If the value of customizable variable `casual-lib-use-unicode'
-is non-nil, then the Unicode symbol is returned, otherwise a
-plain ASCII-range string."
-  (casual-lib-unicode-db-get key casual-editkit-unicode-db))
-
-(defconst casual-editkit-navigation-group
-  [:class transient-row
-   (casual-lib-quit-one)
-   ("U" "Undo" undo :transient t)
-   (casual-lib-quit-all)]
-  "Transient navigation group for Casual EditKit menus.")
-
-
-(defconst casual-editkit-cursor-navigation-group
-  ["Cursor"
-   :class transient-row
-   ("<left>" "←" backward-char :transient t)
-   ("<right>" "→" forward-char :transient t)
-   ("<up>" "↑" previous-line :transient t)
-   ("<down>" "↓" next-line :transient t)])
+(require 'casual-editkit-constants)
 
 ;;; Predicates
 

--- a/lisp/casual-editkit-version.el
+++ b/lisp/casual-editkit-version.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2024 Charles Choi
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
-;; Keywords: tools
+;; Keywords: tools, wp
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/lisp/casual-editkit.el
+++ b/lisp/casual-editkit.el
@@ -4,7 +4,7 @@
 
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-editkit
-;; Keywords: tools
+;; Keywords: tools, wp
 ;; Version: 1.0.4
 ;; Package-Requires: ((emacs "29.1") (casual-lib "1.1.0") (casual-symbol-overlay "1.0.1") (magit "4.0.0"))
 

--- a/tests/test-casual-editkit-constants.el
+++ b/tests/test-casual-editkit-constants.el
@@ -1,0 +1,56 @@
+;;; test-casual-editkit-constants.el --- Tests for casual-editkit-constants  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2024  Charles Choi
+
+;; Author: Charles Choi <kickingvegas@gmail.com>
+;; Keywords: tools
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+(require 'ert)
+(require 'casual-editkit-test-utils)
+(require 'casual-editkit-utils)
+
+(defun casualt-unicode-db-assert (key control cmd)
+  (let ((test (funcall cmd key)))
+    (should (string= test control))))
+
+(defun casualt-editkit-unicode-assert (key control)
+  (casualt-unicode-db-assert key control #'casual-editkit-unicode-get))
+
+(ert-deftest test-casual-editkit-unicode-get ()
+  (let ((casual-lib-use-unicode nil))
+    (casualt-editkit-unicode-assert :previous "previous")
+    (casualt-editkit-unicode-assert :next "next")
+    (casualt-editkit-unicode-assert :first "first")
+    (casualt-editkit-unicode-assert :last "last")
+    (casualt-editkit-unicode-assert :swap "Swap")
+    (casualt-editkit-unicode-assert :jump "Jump"))
+
+  (let ((casual-lib-use-unicode t))
+    (casualt-editkit-unicode-assert :previous "↑")
+    (casualt-editkit-unicode-assert :next "↓")
+    (casualt-editkit-unicode-assert :first "⤒")
+    (casualt-editkit-unicode-assert :last "⤓")
+    (casualt-editkit-unicode-assert :swap "⇄")
+    (casualt-editkit-unicode-assert :jump "🚀")))
+
+
+(provide 'test-casual-editkit-constants)
+;;; test-casual-editkit-constants.el ends here

--- a/tests/test-casual-editkit-utils.el
+++ b/tests/test-casual-editkit-utils.el
@@ -27,30 +27,6 @@
 (require 'casual-editkit-test-utils)
 (require 'casual-editkit-utils)
 
-(defun casualt-unicode-db-assert (key control cmd)
-  (let ((test (funcall cmd key)))
-    (should (string= test control))))
-
-(defun casualt-editkit-unicode-assert (key control)
-  (casualt-unicode-db-assert key control #'casual-editkit-unicode-get))
-
-(ert-deftest test-casual-editkit-unicode-get ()
-  (let ((casual-lib-use-unicode nil))
-    (casualt-editkit-unicode-assert :previous "previous")
-    (casualt-editkit-unicode-assert :next "next")
-    (casualt-editkit-unicode-assert :first "first")
-    (casualt-editkit-unicode-assert :last "last")
-    (casualt-editkit-unicode-assert :swap "Swap")
-    (casualt-editkit-unicode-assert :jump "Jump"))
-
-  (let ((casual-lib-use-unicode t))
-    (casualt-editkit-unicode-assert :previous "↑")
-    (casualt-editkit-unicode-assert :next "↓")
-    (casualt-editkit-unicode-assert :first "⤒")
-    (casualt-editkit-unicode-assert :last "⤓")
-    (casualt-editkit-unicode-assert :swap "⇄")
-    (casualt-editkit-unicode-assert :jump "🚀")))
-
 (ert-deftest test-casual-editkit-open-tmenu ()
   (let ((tmpfile "casual-editkit-open-tmenu.txt"))
     (casualt-setup tmpfile)


### PR DESCRIPTION
- MELPA review surfaced issue with Transient macros being expanded before
`defconst` forms during byte-compilation.

  Fix/workaround is to place `defconst` forms into a separate file to be
  byte-compiled, then is imported (required) into file containing macro
  referencing the `defconst`.

- Added wp keyword.
