### PR TITLE
Merge development to main 20240930_152118

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ create-release-tag: checkout-main bump
 
 create-gh-release: VERSION_BUMP:=$(shell python -m semver nextver $(VERSION) $(BUMP_LEVEL))
 create-gh-release: create-release-tag
-	gh release create -t v$(VERSION_BUMP) --notes-from-tag $(VERSION_LAST_TAG)
+	gh release create -t v$(VERSION_BUMP) --generate-notes
 
 status:
 	git status

--- a/lisp/casual-editkit-version.el
+++ b/lisp/casual-editkit-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-editkit-version "1.0.11"
+(defconst casual-editkit-version "1.0.12-rc.1"
   "Casual EditKit Version.")
 
 (defun casual-editkit-version ()

--- a/lisp/casual-editkit-version.el
+++ b/lisp/casual-editkit-version.el
@@ -22,7 +22,7 @@
 
 ;;; Code:
 
-(defconst casual-editkit-version "1.0.11-rc.1"
+(defconst casual-editkit-version "1.0.11"
   "Casual EditKit Version.")
 
 (defun casual-editkit-version ()

--- a/lisp/casual-editkit.el
+++ b/lisp/casual-editkit.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-editkit
 ;; Keywords: tools, wp
-;; Version: 1.0.11-rc.1
+;; Version: 1.0.11
 ;; Package-Requires: ((emacs "29.1") (casual-lib "1.1.0") (casual-symbol-overlay "1.0.1") (magit "4.0.0") (transpose-frame "0.2.1"))
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/lisp/casual-editkit.el
+++ b/lisp/casual-editkit.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/casual-editkit
 ;; Keywords: tools, wp
-;; Version: 1.0.11
+;; Version: 1.0.12-rc.1
 ;; Package-Requires: ((emacs "29.1") (casual-lib "1.1.0") (casual-symbol-overlay "1.0.1") (magit "4.0.0") (transpose-frame "0.2.1"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Bump version to 1.0.11**
  

- **Bump version to 1.0.12-rc.1**
  

- **Fix notes generation, yet again.**
  - Change to use --generate-notes option instead of --notes-from-tag.
  